### PR TITLE
Do not remove label from closed issues

### DIFF
--- a/action.rb
+++ b/action.rb
@@ -6,9 +6,8 @@ label = ENV["LABEL"]
 client = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
 client.auto_paginate = true
 
-open_issues = client.list_issues(repo, { :labels =>  label})
+open_issues = client.list_issues(repo, { :labels =>  label, :state => 'open'})
 
 open_issues.each do |issue|
   client.close_issue(repo, issue.number)
-  client.remove_label(repo, issue.number, label)
 end


### PR DESCRIPTION
👋 Thanks for this amazin' Action.

I use this in my own workflows and would like the label to persist after the issue is closed, at the moment this action removes it. This PR changes the Action to only obtain open issues with the supplied label, removing the requirement to remove the label after close.
